### PR TITLE
feat: CLI enhancements and Finder visibility

### DIFF
--- a/Demo.md
+++ b/Demo.md
@@ -22,8 +22,8 @@ Listening for traffic on rnode://cfae6a0c885d734908f8c756fb0519d2df7fbcec@178.15
 Local shard will be configured with the following configurations:
 - [REV Addresses (wallets.txt)](./local-shard/genesis/wallets.txt)
 - nodes (see [local-shard/shard-with-autopropose.yml](local-shard/shard-with-autopropose.yml) for Node configs): 
-  - bootstrap node: `localhost:40412`
-  - observer node: `localhost:40442`
+  - bootstrap node: `localhost:40402`
+  - observer node: `localhost:40403`
 
 **Note**: Make sure you have a `.env` file in the `local-shard/` directory with the required environment variables before running docker-compose.
 
@@ -31,29 +31,29 @@ Local shard will be configured with the following configurations:
 
 1. Download the latest `f1r3drive-*.jar` from the [GitHub Releases page](https://github.com/f1r3fly-io/F1R3FLYFS/releases).
 
-2. Run F1r3Drive app with REV Address and Private key. That must be assosiated with some REV address from [wallets.txt](./local-shard/data/genesis/wallets.txt):
+2. Run F1r3Drive app with REV Address and Private key. That must be associated with some REV address from [wallets.txt](./local-shard/data/genesis/wallets.txt):
 
-**Manual Propose Option:**
-- `--manual-propose true`: Manual deployment flow with propose and finalization waiting (for development/testing only)
-- `--manual-propose false`: Deploy only, skip propose and finalization waiting (production shards will do auto-propose)
+**Auto-Propose Option:**
+- `--auto-propose`: The shard handles block proposals automatically (e.g. via autopropose service or heartbeat). F1r3Drive only deploys.
+- Without `--auto-propose`: F1r3Drive manually proposes and waits for finalization after each deploy (for development/testing).
 
 - If you build the jar locally, run:
 ```sh
 java -jar ./build/libs/f1r3drive-0.1.1.jar ~/demo-f1r3drive \
-   --cipher-key-path ~/cipher.key \
-   --validator-host localhost --validator-port 40402 \
-   --observer-host localhost --observer-port 40412 \
-   --manual-propose=false \
-   --rev-address 111127RX5ZgiAdRaQy4AWy57RdvAAckdELReEBxzvWYVvdnR32PiHA --private-key 357cdc4201a5650830e0bc5a03299a30038d9934ba4c7ab73ec164ad82471ff9
+   --key-file ~/cipher.key \
+   --host localhost --port 40402 \
+   --observer-host localhost --observer-port 40403 \
+   --auto-propose \
+   --address 111127RX5ZgiAdRaQy4AWy57RdvAAckdELReEBxzvWYVvdnR32PiHA --private-key 357cdc4201a5650830e0bc5a03299a30038d9934ba4c7ab73ec164ad82471ff9
 ```
 - If you downloaded the JAR to your `~/Downloads` folder, run:
 ```sh
 java -jar ~/Downloads/f1r3drive-0.1.1.jar ~/demo-f1r3drive \
-   --cipher-key-path ~/cipher.key \
-   --validator-host localhost --validator-port 40402 \
-   --observer-host localhost --observer-port 40412 \
-   --manual-propose=false \
-   --rev-address 111127RX5ZgiAdRaQy4AWy57RdvAAckdELReEBxzvWYVvdnR32PiHA --private-key 357cdc4201a5650830e0bc5a03299a30038d9934ba4c7ab73ec164ad82471ff9
+   --key-file ~/cipher.key \
+   --host localhost --port 40402 \
+   --observer-host localhost --observer-port 40403 \
+   --auto-propose \
+   --address 111127RX5ZgiAdRaQy4AWy57RdvAAckdELReEBxzvWYVvdnR32PiHA --private-key 357cdc4201a5650830e0bc5a03299a30038d9934ba4c7ab73ec164ad82471ff9
 ```
 
 # Demo

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The resulting JAR will be at `build/libs/f1r3drive-<version>.jar`.
 ```bash
 java -jar f1r3drive-<version>.jar <mount-point> \
   --key-file <path-to-key> \
-  [--auto-propose] \
+  [--manual-propose] \
   [--host <host>] [--port <port>] \
   [--observer-host <host>] [--observer-port <port>] \
   [--address <rev-address> --private-key <key>] \
@@ -97,7 +97,6 @@ java -jar build/libs/f1r3drive-0.1.1.jar ~/demo-f1r3drive \
   --key-file ~/cipher.key \
   --host localhost --port 40402 \
   --observer-host localhost --observer-port 40403 \
-  --auto-propose \
   --address 111127RX5ZgiAdRaQy4AWy57RdvAAckdELReEBxzvWYVvdnR32PiHA \
   --private-key 357cdc4201a5650830e0bc5a03299a30038d9934ba4c7ab73ec164ad82471ff9
 ```

--- a/README.md
+++ b/README.md
@@ -1,63 +1,120 @@
 # F1r3Drive
 
-F1r3Drive is a FUSE implementation in java using Java Native Runtime (JNR) and F1r3fly Node.
+F1r3Drive is a FUSE-based filesystem that stores data on the F1r3fly blockchain. It is built in Java using [JNR-FUSE](https://github.com/SerCeMan/jnr-fuse) and connects to a running F1r3fly node via gRPC.
 
 ## Prerequisites
 
-The only strict prerequisite for running F1r3Drive is having the necessary FUSE libraries for your system.
+The only strict prerequisite is having the FUSE libraries installed for your operating system:
 
-- On macOS, install [macFUSE](https://github.com/macfuse/macfuse/wiki/Getting-Started).
-- On other systems, see the [jnr-fuse installation guide](https://github.com/SerCeMan/jnr-fuse/blob/master/INSTALLATION.md).
+- **macOS** — install [macFUSE](https://github.com/macfuse/macfuse/wiki/Getting-Started).
+- **Linux / Windows** — see the [jnr-fuse installation guide](INSTALLATION.md).
 
 ## Getting Started
 
-There are two main parts to using F1r3Drive: running a F1r3fly shard and running the F1r3Drive application itself.
+There are two parts to using F1r3Drive: running a F1r3fly shard and running the F1r3Drive application.
 
-### 1. Running a F1r3fly shard
+### 1. Running a F1r3fly Shard
 
-F1r3Drive connects to a F1r3fly shard. You have two options:
+F1r3Drive connects to a F1r3fly node's gRPC API. You can either run a local shard or connect to a remote one.
 
--   **Run a local shard using Docker (Recommended for getting started)**
-    This is the easiest way to get a test environment running.
-    -   **Requirement:** [Docker and Docker Compose](https://www.docker.com/).
-    -   **Command:**
-        ```bash
-        docker-compose up -d
-        ```
-    This starts a small, 2-node shard (one validator and one observer).
+#### Local Shard with Docker (Recommended)
 
--   **Connect to an existing remote shard**
-    If you have access to a remote shard, you can configure F1r3Drive to connect to it.
+**Requirement:** [Docker and Docker Compose](https://www.docker.com/).
 
-### 2. Running the F1r3Drive Application
+Two Docker Compose configurations are provided in the `local-shard/` directory:
 
-You can either download a pre-built JAR or build it from the source code.
+| Config | Nodes | Use case |
+|--------|-------|----------|
+| `shard-with-autopropose.yml` | 1 bootstrap + 3 validators + 1 readonly observer + autopropose service | Full multi-validator shard for realistic testing |
+| `singleton.yml` | 1 bootstrap + 1 readonly observer | Minimal single-node setup for quick development |
+
+```bash
+cd local-shard
+docker-compose -f shard-with-autopropose.yml up -d
+```
+
+> **Note**: Make sure you have a `.env` file in the `local-shard/` directory with the required environment variables before running docker-compose. See `local-shard/README.md` for wallet information and genesis configuration.
+
+Wait for the "Listening for traffic" log message before connecting F1r3Drive:
+
+```bash
+docker-compose -f shard-with-autopropose.yml logs -f
+```
+
+**Default port mappings (multi-validator shard):**
+
+| Node | Internal gRPC (deploy) | Observer gRPC |
+|------|----------------------|---------------|
+| Bootstrap | `localhost:40402` | `localhost:40403` |
+| Validator 1 | `localhost:40412` | `localhost:40413` |
+| Readonly Observer | `localhost:40442` | `localhost:40443` |
+
+#### Connect to a Remote Shard
+
+If you have access to a remote shard, use the `--host`, `--port`, `--observer-host`, and `--observer-port` flags to point F1r3Drive at it.
+
+### 2. Running F1r3Drive
 
 #### Option A: Use the Pre-built JAR
 
-Download the latest `f1r3drive-*.jar` from the [GitHub Releases page](https://github.com/f1r3fly-io/F1R3FLYFS/releases).
-
-**To run the JAR, you need Java 17.**
-If you have cloned this repository and have `direnv` installed, you can simply run `direnv allow` in the project root to get a shell with the correct Java version.
+Download the latest `f1r3drive-*.jar` from the [GitHub Releases page](https://github.com/f1r3fly-io/F1R3FLYFS/releases). Requires **Java 17**.
 
 #### Option B: Build from Source
 
-This is for developers who want to modify or contribute to F1r3Drive.
+**Requirements:** [Nix](https://nixos.org/download/), [direnv](https://direnv.net/#basic-installation), [Protobuf Compiler](https://grpc.io/docs/protoc-installation/)
 
-**Development & Build Requirements:**
-- [Nix](https://nixos.org/download/)
-- [direnv](https://direnv.net/#basic-installation)
-- [Protobuf Compiler](https://grpc.io/docs/protoc-installation/)
+```bash
+# 1. Clone and enter the repository
+git clone https://github.com/f1r3fly-io/F1R3FLYFS.git && cd F1R3FLYFS
 
-**Build Steps:**
-1.  Clone this repository and `cd` into it.
-2.  Run `direnv allow`. This uses Nix to create a shell with all dependencies for the project.
-3.  Build the project with Gradle:
-    ```bash
-    ./gradlew shadowJar -x test
-    ```
-    The resulting JAR file will be in `build/libs/f1r3drive-*.jar`.
+# 2. Set up the development environment via Nix
+direnv allow
+
+# 3. Build the fat JAR
+./gradlew shadowJar -x test
+```
+
+The resulting JAR will be at `build/libs/f1r3drive-<version>.jar`.
 
 ## Usage
 
-Once you have the JAR file and a running shard, see [Demo.md](./Demo.md) for a step-by-step guide on how to mount and use F1r3Drive.
+```bash
+java -jar f1r3drive-<version>.jar <mount-point> \
+  --key-file <path-to-key> \
+  [--auto-propose] \
+  [--host <host>] [--port <port>] \
+  [--observer-host <host>] [--observer-port <port>] \
+  [--address <rev-address> --private-key <key>] \
+  [--debug]
+```
+
+**Quick start example** (connecting to the local multi-validator shard):
+
+> ⚠️ The credentials below are **test-only** keys from `local-shard/README.md`. Do not use them on public shards.
+
+```bash
+java -jar build/libs/f1r3drive-0.1.1.jar ~/demo-f1r3drive \
+  --key-file ~/cipher.key \
+  --host localhost --port 40402 \
+  --observer-host localhost --observer-port 40403 \
+  --auto-propose \
+  --address 111127RX5ZgiAdRaQy4AWy57RdvAAckdELReEBxzvWYVvdnR32PiHA \
+  --private-key 357cdc4201a5650830e0bc5a03299a30038d9934ba4c7ab73ec164ad82471ff9
+```
+
+For the full CLI reference, see **[docs/configuration.md](docs/configuration.md)**.
+For a step-by-step demo walkthrough, see **[Demo.md](Demo.md)**.
+
+## Running Tests
+
+```bash
+# Unit tests
+./gradlew test
+
+# End-to-end tests (requires a running shard)
+./gradlew e2eTest --rerun-tasks
+```
+
+## License
+
+[MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -9,14 +9,19 @@ The only strict prerequisite is having the FUSE libraries installed for your ope
 - **macOS** — install [macFUSE](https://github.com/macfuse/macfuse/wiki/Getting-Started).
 - **Linux / Windows** — see the [jnr-fuse installation guide](INSTALLATION.md).
 
-### macOS Finder Extension (Optional)
+### 🍎 macOS Finder Extension (Optional, but Recommended)
 
-For advanced file and folder operations in Finder (such as custom sync badges and context menus), you can install the [F1r3Drive Extension](https://github.com/F1R3FLY-io/f1r3drive-extension). 
+If you're using a Mac, the core F1r3Drive app gives you everything you need to mount files directly from the blockchain at a basic level:
+- ✅ Unlock and mount a single root folder to your computer
+- ✅ Read, write, and manage files and folders normally
+- ✅ Access the hidden `.token` folder to manage permissions manually
 
-This extension is **optional**. Without it, the basic FUSE functionality works perfectly out of the box:
-- Unlocking a single root folder
-- Basic read/write operations for files and folders
-- Accessing the hidden `.token` configuration folder
+**Want a more native, seamless experience?**
+To get advanced, Dropbox-style features right inside Finder, install the [**F1R3Drive Finder Extension**](https://github.com/F1R3FLY-io/f1r3drive-extension)! 
+
+Installing the extension unlocks:
+- 🎨 **Status Badges**: See exactly which files are synced or pending right on their icons.
+- 🖱️ **Context Menus**: Right-click any file or folder to easily manage `.token` configuration files, share links, or control permissions without opening the terminal.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,15 @@ The only strict prerequisite is having the FUSE libraries installed for your ope
 - **macOS** — install [macFUSE](https://github.com/macfuse/macfuse/wiki/Getting-Started).
 - **Linux / Windows** — see the [jnr-fuse installation guide](INSTALLATION.md).
 
+### macOS Finder Extension (Optional)
+
+For advanced file and folder operations in Finder (such as custom sync badges and context menus), you can install the [F1r3Drive Extension](https://github.com/F1R3FLY-io/f1r3drive-extension). 
+
+This extension is **optional**. Without it, the basic FUSE functionality works perfectly out of the box:
+- Unlocking a single root folder
+- Basic read/write operations for files and folders
+- Accessing the hidden `.token` configuration folder
+
 ## Getting Started
 
 There are two parts to using F1r3Drive: running a F1r3fly shard and running the F1r3Drive application.

--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,7 @@ java {
 
 shadowJar {
     mergeServiceFiles()
-    archiveClassifier = '' // Remove classifier to make this the main JAR
+    archiveFileName = 'f1r3drive-app.jar' // Use specific name to avoid collision with standard jar
     relocate 'org.objectweb.asm', 'org.objectweb.asm.shaded'
     
     manifest {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,10 +67,10 @@ When both `--address` and `--private-key` are provided, F1r3Drive mounts the fil
 
 | Short | Long | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| — | `--auto-propose` | No | `false` | Enable auto-propose mode. |
+| — | `--manual-propose` | No | `false` | Enable manual block proposing. |
 
-- **Without `--auto-propose`** (default) — F1r3Drive proposes blocks manually after each deploy and waits for finalization. Use this for development and testing against shards without an auto-propose mechanism.
-- **With `--auto-propose`** — F1r3Drive deploys contracts but does not propose. The shard is expected to handle block proposals automatically (e.g., via the heartbeat proposer or the `autopropose` service in `shard-with-autopropose.yml`). Use this for production shards.
+- **Without `--manual-propose`** (default) — F1r3Drive deploys contracts but does not propose. The shard is expected to handle block proposals automatically (e.g., via the heartbeat proposer or the `autopropose` service in `shard-with-autopropose.yml`). Use this for production shards.
+- **With `--manual-propose`** — F1r3Drive proposes blocks manually after each deploy and waits for finalization. Use this for development and testing against shards without an auto-propose mechanism.
 
 ### Debugging
 
@@ -98,7 +98,6 @@ java -jar build/libs/f1r3drive-0.1.1.jar ~/demo-f1r3drive \
   --key-file ~/cipher.key \
   --host localhost --port 40402 \
   --observer-host localhost --observer-port 40403 \
-  --auto-propose \
   --address 111127RX5ZgiAdRaQy4AWy57RdvAAckdELReEBxzvWYVvdnR32PiHA \
   --private-key 357cdc4201a5650830e0bc5a03299a30038d9934ba4c7ab73ec164ad82471ff9
 ```
@@ -110,6 +109,7 @@ java -jar build/libs/f1r3drive-0.1.1.jar ~/demo-f1r3drive \
   --key-file ~/cipher.key \
   --host localhost --port 40402 \
   --observer-host localhost --observer-port 40403 \
+  --manual-propose \
   --address 111127RX5ZgiAdRaQy4AWy57RdvAAckdELReEBxzvWYVvdnR32PiHA \
   --private-key 357cdc4201a5650830e0bc5a03299a30038d9934ba4c7ab73ec164ad82471ff9
 ```
@@ -118,7 +118,8 @@ java -jar build/libs/f1r3drive-0.1.1.jar ~/demo-f1r3drive \
 
 ```bash
 java -jar build/libs/f1r3drive-0.1.1.jar ~/demo-f1r3drive \
-  --key-file ~/cipher.key
+  --key-file ~/cipher.key \
+  --manual-propose
 ```
 
 ### Remote shard
@@ -128,7 +129,6 @@ java -jar f1r3drive-0.1.1.jar ~/f1r3drive-mount \
   --key-file ~/.f1r3drive/cipher.key \
   --host node.f1r3fly.io --port 40402 \
   --observer-host node.f1r3fly.io --observer-port 40403 \
-  --auto-propose \
   --address <your-rev-address> \
   --private-key <your-private-key>
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,134 @@
+# F1r3Drive CLI Configuration Reference
+
+F1r3Drive is launched via the `F1r3DriveCli` class which uses [picocli](https://picocli.info/) for argument parsing.
+
+```bash
+java -jar f1r3drive-<version>.jar <mount-point> [OPTIONS]
+```
+
+## Positional Arguments
+
+| Position | Name | Required | Description |
+|----------|------|----------|-------------|
+| `0` | `<mount-point>` | **Yes** | The local directory path where F1r3Drive will mount the FUSE filesystem. The mount point directory must already exist. |
+
+## Options
+
+### Blockchain Connection
+
+These options configure which F1r3fly node F1r3Drive connects to over gRPC.
+
+F1r3fly nodes expose two gRPC APIs:
+
+- **Validator API** — used for deploying Rholang contracts and proposing blocks.
+- **Observer API** — used for reading data from the blockchain without affecting state.
+
+| Short | Long | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `-H` | `--host` | No | `localhost` | Host of the F1r3fly validator gRPC API. |
+| `-P` | `--port` | No | `40402` | Port of the F1r3fly validator gRPC API. |
+| `-O` | `--observer-host` | No | `localhost` | Host of the F1r3fly observer gRPC API. |
+| — | `--observer-port` | No | `40403` | Port of the F1r3fly observer gRPC API. |
+
+**Example** — connecting to the default local bootstrap node:
+
+```bash
+--host localhost --port 40402 \
+--observer-host localhost --observer-port 40403
+```
+
+**Example** — connecting to a remote node:
+
+```bash
+--host node.example.com --port 40402 \
+--observer-host node.example.com --observer-port 40403
+```
+
+### Encryption
+
+| Short | Long | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `-k` | `--key-file` | **Yes** | — | Path to the AES cipher key file used for encrypting data on the blockchain. If the file does not exist, a new key is automatically generated and saved at the specified path. |
+
+The cipher key is initialized at startup as a singleton (`AESCipher.init()`) and used throughout the session. Keep this file secure — losing it means you cannot decrypt data you previously stored.
+
+### Wallet / Identity
+
+These options unlock a wallet directory within the mounted filesystem. **Both must be provided together**, or neither — F1r3Drive will exit with an error if only one is given. While individually optional, they are conditionally required as a pair.
+
+| Short | Long | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `-a` | `--address` | No | — | REV address of the wallet to unlock. Must be a valid address from the shard's `wallets.txt`. |
+| `-K` | `--private-key` | No | — | The private key corresponding to the REV address. Used for signing deploys. |
+
+When both `--address` and `--private-key` are provided, F1r3Drive mounts the filesystem **and** unlocks the root directory for that wallet, enabling read/write access to on-chain data. Without these flags, the filesystem is mounted without wallet access.
+
+### Propose Mode
+
+| Short | Long | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| — | `--auto-propose` | No | `false` | Enable auto-propose mode. |
+
+- **Without `--auto-propose`** (default) — F1r3Drive proposes blocks manually after each deploy and waits for finalization. Use this for development and testing against shards without an auto-propose mechanism.
+- **With `--auto-propose`** — F1r3Drive deploys contracts but does not propose. The shard is expected to handle block proposals automatically (e.g., via the heartbeat proposer or the `autopropose` service in `shard-with-autopropose.yml`). Use this for production shards.
+
+### Debugging
+
+| Short | Long | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `-d` | `--debug` | No | `false` | Enable FUSE debug mode for verbose logging of all filesystem operations. Useful for troubleshooting mount or I/O issues. |
+
+## Built-in Help
+
+F1r3Drive supports `--help` and `--version` flags:
+
+```bash
+java -jar f1r3drive-<version>.jar --help
+java -jar f1r3drive-<version>.jar --version
+```
+
+## Full Example Commands
+
+> **Note:** Replace `0.1.1` in the examples below with your actual build version from `gradle.properties`.
+
+### Development (local shard with auto-propose)
+
+```bash
+java -jar build/libs/f1r3drive-0.1.1.jar ~/demo-f1r3drive \
+  --key-file ~/cipher.key \
+  --host localhost --port 40402 \
+  --observer-host localhost --observer-port 40403 \
+  --auto-propose \
+  --address 111127RX5ZgiAdRaQy4AWy57RdvAAckdELReEBxzvWYVvdnR32PiHA \
+  --private-key 357cdc4201a5650830e0bc5a03299a30038d9934ba4c7ab73ec164ad82471ff9
+```
+
+### Development (local singleton shard, manual propose)
+
+```bash
+java -jar build/libs/f1r3drive-0.1.1.jar ~/demo-f1r3drive \
+  --key-file ~/cipher.key \
+  --host localhost --port 40402 \
+  --observer-host localhost --observer-port 40403 \
+  --address 111127RX5ZgiAdRaQy4AWy57RdvAAckdELReEBxzvWYVvdnR32PiHA \
+  --private-key 357cdc4201a5650830e0bc5a03299a30038d9934ba4c7ab73ec164ad82471ff9
+```
+
+### Minimal (no wallet unlock, manual propose against local shard)
+
+```bash
+java -jar build/libs/f1r3drive-0.1.1.jar ~/demo-f1r3drive \
+  --key-file ~/cipher.key
+```
+
+### Remote shard
+
+```bash
+java -jar f1r3drive-0.1.1.jar ~/f1r3drive-mount \
+  --key-file ~/.f1r3drive/cipher.key \
+  --host node.f1r3fly.io --port 40402 \
+  --observer-host node.f1r3fly.io --observer-port 40403 \
+  --auto-propose \
+  --address <your-rev-address> \
+  --private-key <your-private-key>
+```

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,101 @@
+# F1r3Drive — Feature Reference
+
+This document tracks every feature supported by `f1r3drive`, grouped by implementation status. Each item links to the e2e test that validates it or notes why it is planned but not yet enabled.
+
+---
+
+## ✅ Implemented Features (Passing E2E Tests)
+
+### File Operations (CRUD)
+
+| Feature | Description | Test |
+|---------|-------------|------|
+| **Create file** | Create a new file inside an unlocked wallet directory | `shouldCreateRenameGetDeleteFiles` |
+| **Write file** | Write binary (1 MB+) and string data to files | `shouldCreateRenameGetDeleteFiles` |
+| **Read file** | Read file content back and verify against written data | `shouldCreateRenameGetDeleteFiles` |
+| **Rename file** | Rename a file and verify both local and shard state update | `shouldCreateRenameGetDeleteFiles` |
+| **Overwrite / truncate** | Truncate and overwrite existing file content | `shouldCreateRenameGetDeleteFiles` |
+| **Delete file** | Remove a file and verify it disappears locally and on-chain | `shouldCreateRenameGetDeleteFiles` |
+| **Nested files** | Create files inside subdirectories | `shouldCreateRenameGetDeleteFiles` |
+
+### Directory Operations (CRUD)
+
+| Feature | Description | Test |
+|---------|-------------|------|
+| **Create directory** | Create a new directory inside an unlocked wallet | `shouldCreateRenameListDeleteDirectoriesManualPropose` |
+| **Rename directory** | Rename a directory and verify shard consistency | `shouldCreateRenameListDeleteDirectoriesManualPropose` |
+| **Nested directories** | Create deeply nested directory trees (`mkdirs`) | `shouldCreateRenameListDeleteDirectoriesManualPropose` |
+| **Delete directory** | Remove empty directories | `shouldCreateRenameListDeleteDirectoriesManualPropose` |
+| **List directory** | List children of any directory (local + shard) | `shouldCreateRenameListDeleteDirectoriesManualPropose` |
+
+### Directory Operations — Auto-Propose Mode (Heartbeat)
+
+| Feature | Description | Test |
+|---------|-------------|------|
+| **Create / rename / delete with auto-propose** | Same CRUD operations as above, but without manual block proposals — relies on shard heartbeat to finalize | `shouldCreateRenameListDeleteDirectoriesAutoPropose` |
+| **Polling shard state** | Waits up to 120 s for auto-proposer to process and verify operations on-chain | `shouldCreateRenameListDeleteDirectoriesAutoPropose` |
+
+### Wallet & Access Control
+
+| Feature | Description | Test |
+|---------|-------------|------|
+| **Unlock wallet directory** | Provide a valid REV address + private key to unlock a `LOCKED-REMOTE-REV-*` folder | `shouldHandleOperationsWithNotExistingFileAndDirectory` |
+| **Reject invalid keys** | Invalid or mismatched private keys throw `WalletUnlockException` | `shouldHandleOperationsWithNotExistingFileAndDirectory` |
+| **Locked folder isolation** | Locked wallet folders appear empty; contents are inaccessible | `shouldHandleOperationsWithNotExistingFileAndDirectory` |
+| **Non-existent path errors** | Operations on non-existent files/directories fail gracefully | `shouldHandleOperationsWithNotExistingFileAndDirectory` |
+
+### Token Management
+
+| Feature | Description | Test |
+|---------|-------------|------|
+| **`.token` directory** | Appears inside every unlocked wallet directory; contains `*.token` files | `shouldSupportTokenFileOperations` |
+| **Token file properties** | Each `.token` file follows the `<denomination>-REV.<id>.token` naming convention | `shouldSupportTokenFileOperations` |
+| **Change token denomination** | Splitting a token produces 10 smaller-denomination token files | `shouldSupportTokenFileOperations` |
+| **Transfer tokens** | Moving a `.token` file to another wallet folder triggers an on-chain REV transfer | `shouldSupportTokenFileOperations` |
+| **Balance verification** | After transfer, sender balance decreases and receiver balance increases | `shouldSupportTokenFileOperations` |
+| **Read-only `.token` dir** | Direct file creation and writes inside `.tokens` are blocked | `shouldSupportTokenFileOperations` |
+
+### Timestamps & Persistence
+
+| Feature | Description | Test |
+|---------|-------------|------|
+| **Last-modified tracking** | File and directory creation, modification, and rename all update `lastModified` | `shouldTrackLastModifiedDatesForFilesAndDirectories` |
+| **Timestamp persistence** | Timestamps survive unmount → remount cycle | `shouldTrackLastModifiedDatesForFilesAndDirectories` |
+| **Data persistence** | File content survives unmount → remount cycle | `shouldCreateRenameGetDeleteFiles` |
+
+### Platform Integration (macOS)
+
+| Feature | Description |
+|---------|-------------|
+| **Finder sidebar visibility** | Mounts with `-o volname=F1r3Drive -o local` so the drive appears under "Locations" in Finder |
+| **No `.DS_Store` clutter** | `-o noappledouble` prevents macOS metadata files from being written to the blockchain |
+| **Double Ctrl+C hard stop** | First `Ctrl+C` triggers graceful unmount; second forces `Runtime.halt(130)` for instant JVM kill |
+
+---
+
+## 🔌 Extension Features (Requires [F1R3Drive Finder Extension](https://github.com/F1R3FLY-io/f1r3drive-extension))
+
+These features require installing the optional macOS Finder Extension. They communicate with `f1r3drive` over a local gRPC server on `localhost:54000`.
+
+| Feature | Description |
+|---------|-------------|
+| **Context menu → Change token** | Right-click a `.token` file in Finder and select "Change" to trigger denomination splitting via gRPC `SubmitAction` |
+| **Auto-unlock via Finder navigation** | Navigating into a `LOCKED-REMOTE-REV-*` folder launches `RevFolderUnlockerApp` which prompts for a private key |
+| **MacFUSE mount detection** | Extension polls every 5 s for new MacFUSE volumes and auto-binds Finder Sync to them |
+| **Deep linking (`f1r3drive://`)** | Opening `f1r3drive://unlock?revAddress=<ADDRESS>` launches the unlocker UI pre-filled for that address |
+
+---
+
+## 🚧 Planned Features (Disabled E2E Tests — TODO)
+
+These tests exist in the codebase but are currently marked `@Disabled`. They represent features that are partially implemented or awaiting upstream support.
+
+| Feature | Test Name | Reason / Notes |
+|---------|-----------|----------------|
+| **Deploy `.rho` file** | `shouldStoreRhoFileAndDeployIt` | Store a Rholang source file and deploy it to the blockchain |
+| **Deploy `.metta` file** | `shouldStoreMettaFileAndDeployIt` | Store a MeTTa source file and deploy it (requires correct Metta code) |
+| **Rename `.txt` → `.rho` triggers deploy** | `shouldDeployRhoFileAfterRename` | Renaming a text file to `.rho` should auto-deploy it |
+| **Rename `.txt` → `.metta` triggers deploy** | `shouldDeployMettaFileAfterRename` | Renaming a text file to `.metta` should auto-deploy it |
+| **Transparent encryption (`.encrypted`)** | `shouldEncryptOnSaveAndDecryptOnReadForEncryptedExtension` | Files saved with `.encrypted` extension are AES-encrypted on write and decrypted on read |
+| **Encryption via rename** | `shouldEncryptOnChangingExtension` | Renaming a file to/from `.encrypted` triggers encryption/decryption |
+| **Large file support (512 MB)** | `shouldWriteAndReadLargeFile` | Write and read a 512 MB binary file, verify content survives remount |

--- a/src/main/java/io/f1r3fly/f1r3drive/app/F1r3DriveCli.java
+++ b/src/main/java/io/f1r3fly/f1r3drive/app/F1r3DriveCli.java
@@ -17,12 +17,25 @@ import java.util.concurrent.Callable;
     description = "A FUSE filesystem that stores data on the F1r3fly blockchain.")
 class F1r3DriveCli implements Callable<Integer> {
 
-    private static final String[] MOUNT_OPTIONS = {
-        // Linux-compatible FUSE mount options
+    private static String[] getMountOptions() {
+        String os = System.getProperty("os.name").toLowerCase();
+        if (os.contains("mac")) {
+            return new String[] {
+                "-o", "fsname=f1r3drive",
+                "-o", "volname=F1r3Drive",
+                "-o", "local",
+                "-o", "noappledouble",
+                "-o", "noatime",
+                "-s"
+            };
+        } else {
+            return new String[] {
                 "-o", "fsname=f1r3drive",
                 "-o", "noatime",
-                "-s"  // Single-threaded mode for better FUSE2 compatibility and safety
-    };
+                "-s"
+            };
+        }
+    }
 
     // --- Blockchain connection ---
 
@@ -137,9 +150,9 @@ class F1r3DriveCli implements Callable<Integer> {
 
         // Mount filesystem - unmounting is handled by shutdown hook
         if (wallet != null) {
-            f1r3DriveFuse.mountAndUnlockRootDirectory(mountPoint, true, fuseDebug, wallet.revAddress, wallet.privateKey, MOUNT_OPTIONS);
+            f1r3DriveFuse.mountAndUnlockRootDirectory(mountPoint, true, fuseDebug, wallet.revAddress, wallet.privateKey, getMountOptions());
         } else {
-            f1r3DriveFuse.mount(mountPoint, true, fuseDebug, MOUNT_OPTIONS);
+            f1r3DriveFuse.mount(mountPoint, true, fuseDebug, getMountOptions());
         }
         return 0;
     }

--- a/src/main/java/io/f1r3fly/f1r3drive/app/F1r3DriveCli.java
+++ b/src/main/java/io/f1r3fly/f1r3drive/app/F1r3DriveCli.java
@@ -84,11 +84,11 @@ class F1r3DriveCli implements Callable<Integer> {
 
     // --- Propose mode ---
 
-    @Option(names = {"--auto-propose"},
-        description = "Enable auto-propose mode: skip manual propose and finalization waiting. " +
-            "Use when the shard handles block proposals automatically (e.g. heartbeat or autopropose service). " +
-            "Without this flag, F1r3Drive proposes blocks manually after each deploy.")
-    private boolean autoPropose = false;
+    @Option(names = {"--manual-propose"},
+        description = "Enable manual block proposing after each deploy and wait for finalization. " +
+            "Without this flag (default), F1r3Drive skips proposing and expects the shard to handle it " +
+            "(e.g. heartbeat or autopropose service).")
+    private boolean manualPropose = false;
 
     // --- Debug ---
 
@@ -102,9 +102,6 @@ class F1r3DriveCli implements Callable<Integer> {
     @Override
     public Integer call() throws Exception {
         AESCipher.init(cipherKeyPath); // init singleton instance
-
-        // autoPropose means skip manual propose; manualPropose is the inverse
-        boolean manualPropose = !autoPropose;
 
         F1r3flyBlockchainClient f1R3FlyBlockchainClient = new F1r3flyBlockchainClient(
             validatorHost,

--- a/src/main/java/io/f1r3fly/f1r3drive/app/F1r3DriveCli.java
+++ b/src/main/java/io/f1r3fly/f1r3drive/app/F1r3DriveCli.java
@@ -105,7 +105,7 @@ class F1r3DriveCli implements Callable<Integer> {
             f1R3FlyBlockchainClient
         );
 
-        // Add shutdown hook to ensure proper unmounting on Ctrl+C
+        // Add shutdown hook to ensure proper unmounting on Ctrl+C or kill
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             if (f1r3DriveFuse != null) {
                 try {
@@ -115,6 +115,25 @@ class F1r3DriveCli implements Callable<Integer> {
                 }
             }
         }, "F1r3Drive-Shutdown"));
+
+        try {
+            sun.misc.Signal.handle(new sun.misc.Signal("INT"), new sun.misc.SignalHandler() {
+                private int count = 0;
+                @Override
+                public void handle(sun.misc.Signal sig) {
+                    count++;
+                    if (count >= 2) {
+                        System.err.println("\nDouble Ctrl+C detected. Forcing hard stop!");
+                        Runtime.getRuntime().halt(130);
+                    } else {
+                        System.err.println("\nInterrupt received. Unmounting... (Press Ctrl+C again to force quit)");
+                        new Thread(() -> System.exit(130)).start();
+                    }
+                }
+            });
+        } catch (Throwable t) {
+            System.err.println("Signal handling to detect double Ctrl+C not supported: " + t.getMessage());
+        }
 
         // Mount filesystem - unmounting is handled by shutdown hook
         if (wallet != null) {

--- a/src/main/java/io/f1r3fly/f1r3drive/app/F1r3DriveCli.java
+++ b/src/main/java/io/f1r3fly/f1r3drive/app/F1r3DriveCli.java
@@ -4,6 +4,7 @@ import io.f1r3fly.f1r3drive.app.linux.fuse.F1r3DriveFuse;
 import io.f1r3fly.f1r3drive.encryption.AESCipher;
 import io.f1r3fly.f1r3drive.blockchain.client.F1r3flyBlockchainClient;
 import picocli.CommandLine;
+import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
@@ -11,8 +12,9 @@ import picocli.CommandLine.Parameters;
 import java.nio.file.Path;
 import java.util.concurrent.Callable;
 
-@Command(name = "f1r3FUSE", mixinStandardHelpOptions = true, version = "f1r3FUSE 1.0",
-    description = "A FUSE filesystem based on the F1r3fly blockchain.")
+@Command(name = "f1r3drive", mixinStandardHelpOptions = true,
+    version = "f1r3drive 0.1.1", // NOTE: keep in sync with gradle.properties
+    description = "A FUSE filesystem that stores data on the F1r3fly blockchain.")
 class F1r3DriveCli implements Callable<Integer> {
 
     private static final String[] MOUNT_OPTIONS = {
@@ -22,34 +24,63 @@ class F1r3DriveCli implements Callable<Integer> {
                 "-s"  // Single-threaded mode for better FUSE2 compatibility and safety
     };
 
-    @Option(names = {"-h", "--validator-host"}, description = "Host of the F1r3fly blockchain internal gRPC API to connect to. Defaults to localhost.")
+    // --- Blockchain connection ---
+
+    @Option(names = {"-H", "--host"},
+        description = "Host of the F1r3fly validator gRPC API (default: ${DEFAULT-VALUE}).")
     private String validatorHost = "localhost";
 
-    @Option(names = {"-p", "--validator-port"}, description = "Port of the F1r3fly blockchain internal gRPC API to connect to. Defaults to 40402.")
+    @Option(names = {"-P", "--port"},
+        description = "Port of the F1r3fly validator gRPC API (default: ${DEFAULT-VALUE}).")
     private int validatorPort = 40402;
 
-    @Option(names = {"-oh", "--observer-host"}, description = "Host of the F1r3fly blockchain observer gRPC API to connect to. Defaults to localhost.")
+    @Option(names = {"-O", "--observer-host"},
+        description = "Host of the F1r3fly observer gRPC API (default: ${DEFAULT-VALUE}).")
     private String observerHost = "localhost";
 
-    @Option(names = {"-op", "--observer-port"}, description = "Port of the F1r3fly blockchain observer gRPC API to connect to. Defaults to 40403.")
+    @Option(names = {"--observer-port"},
+        description = "Port of the F1r3fly observer gRPC API (default: ${DEFAULT-VALUE}).")
     private int observerPort = 40403;
 
-    @Option(names = {"-ck", "--cipher-key-path"}, required = true, description = "Cipher key path. If file not found, a new key will be generated.")
+    // --- Security ---
+
+    @Option(names = {"-k", "--key-file"}, required = true,
+        description = "Path to the AES cipher key file. A new key is generated if the file does not exist.")
     private String cipherKeyPath;
 
-    @Parameters(index = "0", description = "The path at which to mount the filesystem.")
+    // --- Mount point ---
+
+    @Parameters(index = "0",
+        description = "Directory path where the FUSE filesystem will be mounted.")
     private Path mountPoint;
 
-    @Option(names = {"-ra", "--rev-address"}, description = "The rev address of the wallet to unlock.")
-    private String revAddress;
+    // --- Wallet / identity ---
 
-    @Option(names = {"-pk", "--private-key"}, description = "The private key of the wallet to unlock.")
-    private String privateKey;
+    static class WalletOptions {
+        @Option(names = {"-a", "--address"}, required = true,
+            description = "REV address of the wallet to unlock.")
+        String revAddress;
 
-    @Option(names = {"-mp", "--manual-propose"}, required = true, description = "Manual propose configuration. If true, will propose and wait for finalization. If false, will skip propose and finalization waiting.")
-    private boolean manualPropose;
+        @Option(names = {"-K", "--private-key"}, required = true,
+            description = "Private key of the wallet (must be used together with --address).")
+        String privateKey;
+    }
 
-    @Option(names = {"-d", "--debug"}, description = "Enable FUSE debug mode for verbose logging of filesystem operations.")
+    @ArgGroup(exclusive = false, multiplicity = "0..1")
+    private WalletOptions wallet;
+
+    // --- Propose mode ---
+
+    @Option(names = {"--auto-propose"},
+        description = "Enable auto-propose mode: skip manual propose and finalization waiting. " +
+            "Use when the shard handles block proposals automatically (e.g. heartbeat or autopropose service). " +
+            "Without this flag, F1r3Drive proposes blocks manually after each deploy.")
+    private boolean autoPropose = false;
+
+    // --- Debug ---
+
+    @Option(names = {"-d", "--debug"},
+        description = "Enable FUSE debug mode for verbose logging of filesystem operations.")
     private boolean fuseDebug = false;
 
     private F1r3DriveFuse f1r3DriveFuse;
@@ -58,6 +89,9 @@ class F1r3DriveCli implements Callable<Integer> {
     @Override
     public Integer call() throws Exception {
         AESCipher.init(cipherKeyPath); // init singleton instance
+
+        // autoPropose means skip manual propose; manualPropose is the inverse
+        boolean manualPropose = !autoPropose;
 
         F1r3flyBlockchainClient f1R3FlyBlockchainClient = new F1r3flyBlockchainClient(
             validatorHost,
@@ -83,16 +117,14 @@ class F1r3DriveCli implements Callable<Integer> {
         }, "F1r3Drive-Shutdown"));
 
         // Mount filesystem - unmounting is handled by shutdown hook
-        if (revAddress != null && privateKey != null) {
-            f1r3DriveFuse.mountAndUnlockRootDirectory(mountPoint, true, fuseDebug, revAddress, privateKey, MOUNT_OPTIONS);
+        if (wallet != null) {
+            f1r3DriveFuse.mountAndUnlockRootDirectory(mountPoint, true, fuseDebug, wallet.revAddress, wallet.privateKey, MOUNT_OPTIONS);
         } else {
             f1r3DriveFuse.mount(mountPoint, true, fuseDebug, MOUNT_OPTIONS);
         }
         return 0;
     }
 
-    // this example implements Callable, so parsing, error handling and handling user
-    // requests for usage help or version help can be done with one line of code.
     public static void main(String... args) {
         int exitCode = new CommandLine(new F1r3DriveCli()).execute(args);
         System.exit(exitCode);


### PR DESCRIPTION
## Overview

This PR introduces necessary CLI enhancements, fixes compilation output collisions, significantly improves the macOS mounting experience, and adds comprehensive documentation including a full feature reference.

## Key Changes

### 1. Double `Ctrl+C` Hard Stop
- **What**: Added a `sun.misc.Signal` interceptor for `SIGINT`.
- **Why**: Allows the user to forcefully halt the JVM (`Runtime.getRuntime().halt(130)`) if the FUSE unmount sequence hangs on the first `Ctrl+C`.

### 2. MacFUSE Finder Visibility
- **What**: Dynamically injects `-o volname=F1r3Drive`, `-o local`, and `-o noappledouble` when running on macOS.
- **Why**: Ensures the mounted drive shows up natively in the Finder sidebar under "Locations" and prevents macOS from cluttering the blockchain with `.DS_Store` and `._` files.

### 3. Propose Mode Refactoring & Build Fixes
- **What**: Replaced `--auto-propose` with `--manual-propose` (default `false`). Changed `build.gradle` `shadowJar` output to `f1r3drive-app.jar`.
- **Why**: Manual block proposal wait sequences are now securely skipped by default, avoiding clashes with shard heartbeat proposers. The jar filename change fixes a corruption issue where the `jar` task was clobbered concurrently.

### 4. Documentation
- **What**: Re-wrote `README.md` and `docs/configuration.md`. Added **`docs/features.md`** — a comprehensive feature reference.
- **Why**: Made documents friendlier for newcomers. The new `features.md` maps every implemented feature to its passing e2e test, documents extension-only features, and tracks planned features (disabled tests) as a TODO backlog.

### New: `docs/features.md`

The feature reference covers:
- ✅ **Implemented** — File CRUD, Directory CRUD, Auto-Propose mode, Wallet & Access Control, Token Management, Timestamps & Persistence, and macOS Platform Integration
- 🔌 **Extension Features** — Context menus, auto-unlock, mount detection, deep linking (requires [f1r3drive-extension](https://github.com/F1R3FLY-io/f1r3drive-extension))
- 🚧 **Planned (TODO)** — `.rho`/`.metta` deployment, transparent encryption, 512 MB large file support
