### PR TITLE
fix: return immutable blockchain directory children

### DIFF
--- a/src/main/java/io/f1r3fly/f1r3drive/filesystem/deployable/BlockchainDirectory.java
+++ b/src/main/java/io/f1r3fly/f1r3drive/filesystem/deployable/BlockchainDirectory.java
@@ -118,8 +118,8 @@ public class BlockchainDirectory extends AbstractDeployablePath implements Direc
     }
 
     @Override
-    public Set<Path> getChildren() {
-        return children; // TODO: return immutable set?
+    public synchronized Set<Path> getChildren() {
+        return Set.copyOf(children);
     }
 
 }

--- a/src/test/java/io/f1r3fly/f1r3drive/filesystem/deployable/BlockchainDirectoryTest.java
+++ b/src/test/java/io/f1r3fly/f1r3drive/filesystem/deployable/BlockchainDirectoryTest.java
@@ -1,0 +1,29 @@
+package io.f1r3fly.f1r3drive.filesystem.deployable;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import io.f1r3fly.f1r3drive.blockchain.BlockchainContext;
+import io.f1r3fly.f1r3drive.filesystem.common.Path;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class BlockchainDirectoryTest {
+
+    @Test
+    void getChildrenReturnsImmutableSet() {
+        BlockchainDirectory directory = new BlockchainDirectory(
+                mock(BlockchainContext.class),
+                "directory",
+                null,
+                false);
+        Path child = mock(Path.class);
+        directory.children.add(child);
+
+        Set<Path> children = directory.getChildren();
+
+        assertThrows(UnsupportedOperationException.class, () -> children.add(mock(Path.class)));
+        assertThrows(UnsupportedOperationException.class, () -> children.remove(child));
+        assertThrows(UnsupportedOperationException.class, children::clear);
+    }
+}


### PR DESCRIPTION
Summary
- Return immutable copy from BlockchainDirectory.getChildren()

Changes
- Replaced direct Set return with Set.copyOf(children)
- Added unit test verifying returned set cannot be modified